### PR TITLE
Typo: 'contnet'

### DIFF
--- a/1.x/docs/changelog.html
+++ b/1.x/docs/changelog.html
@@ -6,7 +6,7 @@
         <title>Changelog - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/alerts.html
+++ b/1.x/docs/components/alerts.html
@@ -6,7 +6,7 @@
         <title>Alerts and notifications - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/breadcrumbs.html
+++ b/1.x/docs/components/breadcrumbs.html
@@ -6,7 +6,7 @@
         <title>Breadcrumbs - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/buttons.html
+++ b/1.x/docs/components/buttons.html
@@ -6,7 +6,7 @@
         <title>Buttons - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/collapsiblePanels.html
+++ b/1.x/docs/components/collapsiblePanels.html
@@ -6,7 +6,7 @@
         <title>Collapsible panels - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/dialogs.html
+++ b/1.x/docs/components/dialogs.html
@@ -6,7 +6,7 @@
         <title>Dialogs - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/formControls.html
+++ b/1.x/docs/components/formControls.html
@@ -6,7 +6,7 @@
         <title>Form controls - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/forms.html
+++ b/1.x/docs/components/forms.html
@@ -6,7 +6,7 @@
         <title>Forms - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/labelsAndBadges.html
+++ b/1.x/docs/components/labelsAndBadges.html
@@ -6,7 +6,7 @@
         <title>Labels and badges - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/menus.html
+++ b/1.x/docs/components/menus.html
@@ -6,7 +6,7 @@
         <title>Menus - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/metadata.html
+++ b/1.x/docs/components/metadata.html
@@ -6,7 +6,7 @@
         <title>Metadata - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/pagination.html
+++ b/1.x/docs/components/pagination.html
@@ -6,7 +6,7 @@
         <title>Pagination - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/popovers.html
+++ b/1.x/docs/components/popovers.html
@@ -6,7 +6,7 @@
         <title>Popovers - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/progressBars.html
+++ b/1.x/docs/components/progressBars.html
@@ -6,7 +6,7 @@
         <title>Progress and loading - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/stepIndicators.html
+++ b/1.x/docs/components/stepIndicators.html
@@ -6,7 +6,7 @@
         <title>Step indicators - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/tables.html
+++ b/1.x/docs/components/tables.html
@@ -6,7 +6,7 @@
         <title>Tables - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/tabs.html
+++ b/1.x/docs/components/tabs.html
@@ -6,7 +6,7 @@
         <title>Tabs - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/tags.html
+++ b/1.x/docs/components/tags.html
@@ -6,7 +6,7 @@
         <title>Tags - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/components/tooltips.html
+++ b/1.x/docs/components/tooltips.html
@@ -6,7 +6,7 @@
         <title>Tooltips - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/colors.html
+++ b/1.x/docs/foundation/colors.html
@@ -6,7 +6,7 @@
         <title>Colors - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/grid.html
+++ b/1.x/docs/foundation/grid.html
@@ -6,7 +6,7 @@
         <title>Grid - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/icons.html
+++ b/1.x/docs/foundation/icons.html
@@ -6,7 +6,7 @@
         <title>Icons - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/layouts.html
+++ b/1.x/docs/foundation/layouts.html
@@ -6,7 +6,7 @@
         <title>Layouts - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/layouts/fixed.html
+++ b/1.x/docs/foundation/layouts/fixed.html
@@ -6,7 +6,7 @@
         <title>Fixed layout - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/layouts/fluid.html
+++ b/1.x/docs/foundation/layouts/fluid.html
@@ -6,7 +6,7 @@
         <title>Fluid layout - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/layouts/hybrid.html
+++ b/1.x/docs/foundation/layouts/hybrid.html
@@ -6,7 +6,7 @@
         <title>Hybrid layout - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/layouts/type-content-navigation.html
+++ b/1.x/docs/foundation/layouts/type-content-navigation.html
@@ -6,7 +6,7 @@
         <title>Content and navigation - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/layouts/type-content-only.html
+++ b/1.x/docs/foundation/layouts/type-content-only.html
@@ -6,7 +6,7 @@
         <title>Content only - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/layouts/type-content-sidebar.html
+++ b/1.x/docs/foundation/layouts/type-content-sidebar.html
@@ -6,7 +6,7 @@
         <title>Content with sidebar - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/layouts/type-focused.html
+++ b/1.x/docs/foundation/layouts/type-focused.html
@@ -6,7 +6,7 @@
         <title>Focused task - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/layouts/type-navigation-content-sidebar.html
+++ b/1.x/docs/foundation/layouts/type-navigation-content-sidebar.html
@@ -6,7 +6,7 @@
         <title>Navigation and content with sidebar - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/links.html
+++ b/1.x/docs/foundation/links.html
@@ -6,7 +6,7 @@
         <title>Links - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/typography.html
+++ b/1.x/docs/foundation/typography.html
@@ -6,7 +6,7 @@
         <title>Typography - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/foundation/writingStyle.html
+++ b/1.x/docs/foundation/writingStyle.html
@@ -6,7 +6,7 @@
         <title>Writing style - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/guides/evaluation/usability-testing.html
+++ b/1.x/docs/guides/evaluation/usability-testing.html
@@ -6,7 +6,7 @@
         <title>Usability testing - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/guides/index.html
+++ b/1.x/docs/guides/index.html
@@ -6,7 +6,7 @@
         <title>Guides - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/guides/project/project-close.html
+++ b/1.x/docs/guides/project/project-close.html
@@ -6,7 +6,7 @@
         <title>Transitions - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/index.html
+++ b/1.x/docs/index.html
@@ -6,7 +6,7 @@
         <title>Library - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/beta-content.html
+++ b/1.x/docs/inspiration/beta-content.html
@@ -6,7 +6,7 @@
         <title>Beta content - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/beta.html
+++ b/1.x/docs/inspiration/beta.html
@@ -6,7 +6,7 @@
         <title>Beta - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/createAcct-step1.html
+++ b/1.x/docs/inspiration/createAcct-step1.html
@@ -6,7 +6,7 @@
         <title>Create new account - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/createAcct-step2.html
+++ b/1.x/docs/inspiration/createAcct-step2.html
@@ -6,7 +6,7 @@
         <title>Create new account - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/createAcct-step3.html
+++ b/1.x/docs/inspiration/createAcct-step3.html
@@ -6,7 +6,7 @@
         <title>Create new account - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/dashboard.html
+++ b/1.x/docs/inspiration/dashboard.html
@@ -6,7 +6,7 @@
         <title>Dashboard - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/gadgets.html
+++ b/1.x/docs/inspiration/gadgets.html
@@ -6,7 +6,7 @@
         <title>Gadgets - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/help.html
+++ b/1.x/docs/inspiration/help.html
@@ -6,7 +6,7 @@
         <title>Help - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/marketing.html
+++ b/1.x/docs/inspiration/marketing.html
@@ -6,7 +6,7 @@
         <title>Marketing - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/master-detail-app.html
+++ b/1.x/docs/inspiration/master-detail-app.html
@@ -6,7 +6,7 @@
         <title>Master detail - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/master-detail.html
+++ b/1.x/docs/inspiration/master-detail.html
@@ -6,7 +6,7 @@
         <title>Master detail - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/payments.html
+++ b/1.x/docs/inspiration/payments.html
@@ -6,7 +6,7 @@
         <title>Payments - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/preexam.html
+++ b/1.x/docs/inspiration/preexam.html
@@ -6,7 +6,7 @@
         <title>Preexam - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/results.html
+++ b/1.x/docs/inspiration/results.html
@@ -6,7 +6,7 @@
         <title>Search results - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/search-results.html
+++ b/1.x/docs/inspiration/search-results.html
@@ -6,7 +6,7 @@
         <title>Customize search results - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/signin.html
+++ b/1.x/docs/inspiration/signin.html
@@ -6,7 +6,7 @@
         <title>Sign in - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/user-profile.html
+++ b/1.x/docs/inspiration/user-profile.html
@@ -6,7 +6,7 @@
         <title>User profile - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/inspiration/usersApp.html
+++ b/1.x/docs/inspiration/usersApp.html
@@ -6,7 +6,7 @@
         <title>User details - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/patterns/cards.html
+++ b/1.x/docs/patterns/cards.html
@@ -6,7 +6,7 @@
         <title>Cards - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/patterns/dataFormats.html
+++ b/1.x/docs/patterns/dataFormats.html
@@ -6,7 +6,7 @@
         <title>Data formats - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/patterns/fileUpload.html
+++ b/1.x/docs/patterns/fileUpload.html
@@ -6,7 +6,7 @@
         <title>File upload - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/patterns/filters.html
+++ b/1.x/docs/patterns/filters.html
@@ -6,7 +6,7 @@
         <title>Filters - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/patterns/help.html
+++ b/1.x/docs/patterns/help.html
@@ -6,7 +6,7 @@
         <title>Help - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/patterns/search.html
+++ b/1.x/docs/patterns/search.html
@@ -6,7 +6,7 @@
         <title>Search - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/patterns/settings.html
+++ b/1.x/docs/patterns/settings.html
@@ -6,7 +6,7 @@
         <title>Settings - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/patterns/tours.html
+++ b/1.x/docs/patterns/tours.html
@@ -6,7 +6,7 @@
         <title>Tours - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/patterns/wizards.html
+++ b/1.x/docs/patterns/wizards.html
@@ -6,7 +6,7 @@
         <title>Wizards - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/docs/resources.html
+++ b/1.x/docs/resources.html
@@ -6,7 +6,7 @@
         <title>Resources - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/1.x/index.html
+++ b/1.x/index.html
@@ -6,7 +6,7 @@
         <title>About - USPTO UI Design Library</title>
 
         <meta name="description" content="">
-        <meta name="keywords" contnet="">
+        <meta name="keywords" content="">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/_includes/appDemo/app-head.html
+++ b/_includes/appDemo/app-head.html
@@ -6,7 +6,7 @@
         <title>{{page.title}} - USPTO UI Design Library</title>
 
         <meta name="description" content="{{page.description}}">
-        <meta name="keywords" contnet="{{page.keywords}}">
+        <meta name="keywords" content="{{page.keywords}}">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
         <title>{{page.title}} - USPTO UI Design Library</title>
 
         <meta name="description" content="{{page.description}}">
-        <meta name="keywords" contnet="{{page.keywords}}">
+        <meta name="keywords" content="{{page.keywords}}">
 
         <meta name="viewport" content="width=device-width">
         <meta name="theme-color" content="#004c97">

--- a/docs/inspiration/dashboard.html
+++ b/docs/inspiration/dashboard.html
@@ -11,7 +11,7 @@ preview: true
         <title>{{page.title}} - USPTO UI Design Library</title>
 
         <meta name="description" content="{{page.description}}">
-        <meta name="keywords" contnet="{{page.keywords}}">
+        <meta name="keywords" content="{{page.keywords}}">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
         <meta name="theme-color" content="#004c97">


### PR DESCRIPTION
Typo in "meta keywords" HTML tag: "contnet" -> "content"
See reference to HTML standard on the 'meta' tag: http://www.w3schools.com/tags/tag_meta.asp 